### PR TITLE
Replace namespace for ObsidianRegex

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "builtin-modules": "3.3.0",
         "esbuild": "0.17.11",
         "jest": "^29.5.0",
-        "obsidian": "*",
+        "obsidian": "latest",
         "process": "^0.11.10",
         "ts-jest": "^29.0.5",
         "tslib": "2.5.0",

--- a/src/ObsidianRegex.ts
+++ b/src/ObsidianRegex.ts
@@ -1,7 +1,5 @@
-// FIXME: This is a temporary way to mimic Java's enum.
-// eslint-disable-next-line @typescript-eslint/no-namespace
-export namespace ObsidianRegex {
-    export const IMAGE_LINK = /!\[\[(.*?)]]/g;
-    export const DOCUMENT_LINK = /(?<!!)\[\[(.*?)]]/g;
-    export const CALLOUT = /> \[!(.*)].*?\n(>.*)/ig;
-}
+export const ObsidianRegex = {
+    IMAGE_LINK: /!\[\[(.*?)]]/g,
+    DOCUMENT_LINK: /(?<!!)\[\[(.*?)]]/g,
+    CALLOUT: /> \[!(.*)].*?\n(>.*)/ig,
+} as const;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
The ObsidianRegex file uses a namespace to emulate a Java enum.

Issue Number: N/A


## What is the new behavior?
The ObsidianRegex file now utilises the Typescript [const assertions](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html#const-assertions) to implement this.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
P.S: It may be good to add a .prettierrc config file to the project. Also, I was getting a few TS errors, mostly regarding unspecified `any` types, not sure if this was just me though...