### PR TITLE
fix: o2-53 create folder in assets/img without resource

### DIFF
--- a/src/jekyll/ResourceLinkConverter.ts
+++ b/src/jekyll/ResourceLinkConverter.ts
@@ -18,11 +18,12 @@ export class ResourceLinkConverter extends AbstractConverter {
     convert(input: string): string {
         const jekyllSetting = this.plugin.settings.jekyllSetting();
         const resourcePath = `${jekyllSetting.resourcePath()}/${this.title}`;
-        fs.mkdirSync(resourcePath, { recursive: true });
 
-        const relativeResourcePath = jekyllSetting.jekyllRelativeResourcePath;
-
-        extractImageName(input)?.forEach((resourceName) => {
+        const resourceNames = extractResourceNames(input);
+        if (!(resourceNames === undefined || resourceNames.length === 0)) {
+            fs.mkdirSync(resourcePath, { recursive: true });
+        }
+        resourceNames?.forEach((resourceName) => {
             fs.copyFile(
                 `${(vaultAbsolutePath(this.plugin))}/${jekyllSetting.attachmentsFolder}/${resourceName}`,
                 `${resourcePath}/${(resourceName.replace(/\s/g, '-'))}`,
@@ -36,6 +37,7 @@ export class ResourceLinkConverter extends AbstractConverter {
             );
         });
 
+        const relativeResourcePath = jekyllSetting.jekyllRelativeResourcePath;
         const replacer = (match: string, p1: string) =>
             `![image](/${relativeResourcePath}/${this.title}/${p1.replace(/\s/g, '-')})`;
 
@@ -45,7 +47,7 @@ export class ResourceLinkConverter extends AbstractConverter {
     }
 }
 
-export function extractImageName(content: string) {
+export function extractResourceNames(content: string) {
     const regExpMatchArray = content.match(ObsidianRegex.IMAGE_LINK);
     return regExpMatchArray?.map(
         (value) => {

--- a/src/tests/ResourceLinkConverter.test.ts
+++ b/src/tests/ResourceLinkConverter.test.ts
@@ -1,4 +1,4 @@
-import { extractImageName } from "../jekyll/ResourceLinkConverter";
+import { extractResourceNames } from "../jekyll/ResourceLinkConverter";
 
 jest.mock('obsidian', () => ({}), { virtual: true });
 
@@ -10,7 +10,7 @@ describe("extract image name", () => {
         test
         ![[image.png]]
         `;
-        const result = extractImageName(context);
+        const result = extractResourceNames(context);
         expect(result).toEqual(['test.png', 'image.png']);
     });
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: resolve #53 


## What is the new behavior?

Do not create a folder if Markdown files does not contains any resources.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
