### PR TITLE
feat: image resize syntax

### DIFF
--- a/src/ObsidianRegex.ts
+++ b/src/ObsidianRegex.ts
@@ -1,5 +1,5 @@
 export const ObsidianRegex = {
-    IMAGE_LINK: /!\[\[(.*?)]]/g,
+    IMAGE_LINK: /!\[\[([^|\]]+)\|?(\d*)]]/g,
     DOCUMENT_LINK: /(?<!!)\[\[(.*?)]]/g,
     CALLOUT: /> \[!(.*)].*?\n(>.*)/ig,
 } as const;

--- a/src/jekyll/CalloutConverter.ts
+++ b/src/jekyll/CalloutConverter.ts
@@ -9,11 +9,10 @@ export class CalloutConverter extends AbstractConverter {
     }
 }
 
-export function convertCalloutSyntaxToChirpy(content: string) {
+function convertCalloutSyntaxToChirpy(content: string) {
     function replacer(match: string, p1: string, p2: string) {
         return `${p2}\n{: .prompt-${replaceKeyword(p1)}}`;
     }
 
     return content.replace(ObsidianRegex.CALLOUT, replacer);
 }
-

--- a/src/jekyll/ResourceLinkConverter.ts
+++ b/src/jekyll/ResourceLinkConverter.ts
@@ -38,8 +38,9 @@ export class ResourceLinkConverter extends AbstractConverter {
         });
 
         const relativeResourcePath = jekyllSetting.jekyllRelativeResourcePath;
-        const replacer = (match: string, p1: string) =>
-            `![image](/${relativeResourcePath}/${this.title}/${p1.replace(/\s/g, '-')})`;
+
+        const replacer = (match: string, p1: string, imageSize: string | undefined) =>
+            `![image](/${relativeResourcePath}/${this.title}/${p1.replace(/\s/g, '-')})${convertImageSize(imageSize)}`;
 
         const result = input.replace(ObsidianRegex.IMAGE_LINK, replacer);
 
@@ -48,11 +49,16 @@ export class ResourceLinkConverter extends AbstractConverter {
 }
 
 export function extractResourceNames(content: string) {
-    const regExpMatchArray = content.match(ObsidianRegex.IMAGE_LINK);
-    return regExpMatchArray?.map(
-        (value) => {
-            return value.replace(ObsidianRegex.IMAGE_LINK, '$1');
-        }
-    );
+    const result = content.match(ObsidianRegex.IMAGE_LINK);
+    if (result === null) {
+        return undefined;
+    }
+    return result.map((imageLink) => imageLink.replace(ObsidianRegex.IMAGE_LINK, '$1'));
 }
 
+function convertImageSize(imageSize: string | undefined) {
+    if (imageSize === undefined || imageSize.length === 0) {
+        return '';
+    }
+    return `{ width="${imageSize}" }`;
+}

--- a/src/jekyll/ResourceLinkConverter.ts
+++ b/src/jekyll/ResourceLinkConverter.ts
@@ -1,23 +1,26 @@
 import { AbstractConverter } from "../core/Converter";
 import fs from "fs";
 import { ObsidianRegex } from "../ObsidianRegex";
-import O2Plugin from "../main";
-import { vaultAbsolutePath } from "../utils";
 import { Notice } from "obsidian";
 
 export class ResourceLinkConverter extends AbstractConverter {
-    private readonly plugin: O2Plugin;
-    private readonly title: string;
+    private readonly fileName: string;
+    private readonly resourcePath: string;
+    private readonly absolutePath: string;
+    private readonly attachmentsFolder: string;
+    private readonly relativeResourcePath: string;
 
-    constructor(plugin: O2Plugin, title: string) {
+    constructor(fileName: string, resourcePath: string, absolutePath: string, attachmentsFolder: string, relativeResourcePath: string) {
         super();
-        this.plugin = plugin;
-        this.title = title;
+        this.fileName = fileName;
+        this.resourcePath = resourcePath;
+        this.absolutePath = absolutePath;
+        this.attachmentsFolder = attachmentsFolder;
+        this.relativeResourcePath = relativeResourcePath;
     }
 
     convert(input: string): string {
-        const jekyllSetting = this.plugin.settings.jekyllSetting();
-        const resourcePath = `${jekyllSetting.resourcePath()}/${this.title}`;
+        const resourcePath = `${this.resourcePath}/${this.fileName}`;
 
         const resourceNames = extractResourceNames(input);
         if (!(resourceNames === undefined || resourceNames.length === 0)) {
@@ -25,7 +28,7 @@ export class ResourceLinkConverter extends AbstractConverter {
         }
         resourceNames?.forEach((resourceName) => {
             fs.copyFile(
-                `${(vaultAbsolutePath(this.plugin))}/${jekyllSetting.attachmentsFolder}/${resourceName}`,
+                `${this.absolutePath}/${this.attachmentsFolder}/${resourceName}`,
                 `${resourcePath}/${(resourceName.replace(/\s/g, '-'))}`,
                 (err) => {
                     if (err) {
@@ -37,10 +40,8 @@ export class ResourceLinkConverter extends AbstractConverter {
             );
         });
 
-        const relativeResourcePath = jekyllSetting.jekyllRelativeResourcePath;
-
         const replacer = (match: string, p1: string, imageSize: string | undefined) =>
-            `![image](/${relativeResourcePath}/${this.title}/${p1.replace(/\s/g, '-')})${convertImageSize(imageSize)}`;
+            `![image](/${this.relativeResourcePath}/${this.fileName}/${p1.replace(/\s/g, '-')})${convertImageSize(imageSize)}`;
 
         const result = input.replace(ObsidianRegex.IMAGE_LINK, replacer);
 

--- a/src/jekyll/chirpy.ts
+++ b/src/jekyll/chirpy.ts
@@ -19,15 +19,21 @@ export async function convertToChirpy(plugin: O2Plugin) {
         await backupOriginalNotes(plugin);
         const markdownFiles = await renameMarkdownFile(plugin);
         for (const file of markdownFiles) {
-            const title = file.name.replace('.md', '').replace(/\s/g, '-');
+            const fileName = file.name.replace('.md', '').replace(/\s/g, '-');
 
             const frontMatterConverter = new FrontMatterConverter(
-                title,
+                fileName,
                 plugin.settings.jekyllSetting().jekyllRelativeResourcePath,
                 plugin.settings.jekyllSetting().isEnableBanner
             );
             const bracketConverter = new BracketConverter();
-            const resourceLinkConverter = new ResourceLinkConverter(plugin, title);
+            const resourceLinkConverter = new ResourceLinkConverter(
+                fileName,
+                plugin.settings.jekyllSetting().resourcePath(),
+                vaultAbsolutePath(plugin),
+                plugin.settings.attachmentsFolder,
+                plugin.settings.jekyllSetting().jekyllRelativeResourcePath
+            );
             const calloutConverter = new CalloutConverter();
 
             frontMatterConverter.setNext(bracketConverter)

--- a/src/tests/ObsidianRegex.test.ts
+++ b/src/tests/ObsidianRegex.test.ts
@@ -16,4 +16,12 @@ describe('Image link', () => {
 
         expect(result).toEqual('test.png ');
     });
+
+    // TODO: not yet implemented
+    xit('should not match embedded syntax', () => {
+        const context = '![[Obsidian#What is Obsidian?]]';
+        const result = context.match(ObsidianRegex.IMAGE_LINK);
+
+        expect(result).toBeNull();
+    });
 });

--- a/src/tests/ObsidianRegex.test.ts
+++ b/src/tests/ObsidianRegex.test.ts
@@ -1,0 +1,19 @@
+import { ObsidianRegex } from "../ObsidianRegex";
+
+describe('Image link', () => {
+    it('should separate image name and size', () => {
+        const context = '![[test.png|100]]';
+        // const result = context.match(ObsidianRegex.IMAGE_LINK);
+
+        const result = context.replace(ObsidianRegex.IMAGE_LINK, '$1 $2');
+
+        expect(result).toEqual('test.png 100');
+    });
+
+    it('extract only image name', () => {
+        const context = '![[test.png]]';
+        const result = context.replace(ObsidianRegex.IMAGE_LINK, '$1 $2');
+
+        expect(result).toEqual('test.png ');
+    });
+});

--- a/src/tests/ResourceLinkConverter.test.ts
+++ b/src/tests/ResourceLinkConverter.test.ts
@@ -18,6 +18,12 @@ describe("extract image name", () => {
         expect(result).toEqual(['test.png', 'image.png']);
     });
 
+    it('should return undefined', () => {
+        const context = `test`;
+        const result = extractResourceNames(context);
+        expect(result).toBeUndefined();
+    });
+
 });
 
 describe("convert called", () => {
@@ -31,5 +37,9 @@ describe("convert called", () => {
 
     it('should return converted post', () => {
         expect(converter.convert(`![[test.png]]`)).toEqual(`![image](/assets/2023-01-01-post-mock/test.png)`);
+    });
+
+    it('should return converted post with image size', () => {
+        expect(converter.convert(`![[test.png|100]]`)).toEqual(`![image](/assets/2023-01-01-post-mock/test.png){ width="100" }`);
     });
 });

--- a/src/tests/ResourceLinkConverter.test.ts
+++ b/src/tests/ResourceLinkConverter.test.ts
@@ -1,6 +1,10 @@
-import { extractResourceNames } from "../jekyll/ResourceLinkConverter";
+import { extractResourceNames, ResourceLinkConverter } from "../jekyll/ResourceLinkConverter";
 
 jest.mock('obsidian', () => ({}), { virtual: true });
+jest.mock('fs', () => ({
+    mkdirSync: jest.fn(),
+    copyFile: jest.fn()
+}));
 
 describe("extract image name", () => {
 
@@ -16,3 +20,16 @@ describe("extract image name", () => {
 
 });
 
+describe("convert called", () => {
+    const converter = new ResourceLinkConverter(
+        '2023-01-01-post-mock',
+        'assets',
+        'test',
+        'attachments',
+        'assets'
+    );
+
+    it('should return converted post', () => {
+        expect(converter.convert(`![[test.png]]`)).toEqual(`![image](/assets/2023-01-01-post-mock/test.png)`);
+    });
+});


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Not supported image size syntax

Issue Number: resolve #22 


## What is the new behavior?

`![[Obsidian.png|500]]` is now converted to `![image](<link>/Obsidian.png) { width : "500" }`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
