### PR TITLE
feat: o2-23 support obsidian simple footnote syntax

### DIFF
--- a/src/ObsidianRegex.ts
+++ b/src/ObsidianRegex.ts
@@ -2,4 +2,5 @@ export const ObsidianRegex = {
     IMAGE_LINK: /!\[\[([^|\]]+)\|?(\d*)]]/g,
     WIKI_LINK: /(?<!!)\[\[([^|\]]+)\|?(.*)]]/g,
     CALLOUT: /> \[!(.*)].*?\n(>.*)/ig,
+    SIMPLE_FOOTNOTE: /\[\^(\d+)]/g
 } as const;

--- a/src/jekyll/FootnotesConverter.ts
+++ b/src/jekyll/FootnotesConverter.ts
@@ -1,0 +1,13 @@
+import { AbstractConverter } from "../core/Converter";
+import { ObsidianRegex } from "../ObsidianRegex";
+
+export class FootnotesConverter extends AbstractConverter {
+
+    convert(input: string): string {
+        const result = input.replace(ObsidianRegex.SIMPLE_FOOTNOTE, (match, key) => {
+            return `[^fn-nth-${key}]`;
+        });
+        return super.convert(result);
+    }
+
+}

--- a/src/jekyll/chirpy.ts
+++ b/src/jekyll/chirpy.ts
@@ -8,6 +8,7 @@ import { Notice, TFile } from "obsidian";
 import { CalloutConverter } from "./CalloutConverter";
 import { FrontMatterConverter } from "./FrontMatterConverter";
 import { vaultAbsolutePath } from "../utils";
+import { FootnotesConverter } from "./FootnotesConverter";
 
 export async function convertToChirpy(plugin: O2Plugin) {
     // validation
@@ -35,10 +36,12 @@ export async function convertToChirpy(plugin: O2Plugin) {
                 plugin.settings.jekyllSetting().jekyllRelativeResourcePath
             );
             const calloutConverter = new CalloutConverter();
+            const footnotesConverter = new FootnotesConverter();
 
             frontMatterConverter.setNext(wikiLinkConverter)
                 .setNext(resourceLinkConverter)
-                .setNext(calloutConverter);
+                .setNext(calloutConverter)
+                .setNext(footnotesConverter);
 
             const result = frontMatterConverter.convert(await plugin.app.vault.read(file));
             await plugin.app.vault.modify(file, result);

--- a/src/tests/FootnotesConverter.test.ts
+++ b/src/tests/FootnotesConverter.test.ts
@@ -1,0 +1,34 @@
+import { FootnotesConverter } from "../jekyll/FootnotesConverter";
+
+const converter = new FootnotesConverter();
+
+describe("FootnotesConverter", () => {
+    it("should convert simple footnotes", () => {
+        const contents = `
+# Hello World
+
+This is a simple footnote[^1]. next footnote[^2].
+
+[^1]: meaningful
+
+[^2]: meaningful 2
+
+`;
+
+        const expected = `
+# Hello World
+
+This is a simple footnote[^fn-nth-1]. next footnote[^fn-nth-2].
+
+[^fn-nth-1]: meaningful
+
+[^fn-nth-2]: meaningful 2
+
+`;
+        const actual = converter.convert(contents);
+        expect(actual).toEqual(expected);
+    });
+
+    it.todo("should convert footnotes with multiple lines");
+    it.todo("should convert inline footnotes");
+});


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: resolve #23 

## What is the new behavior?

Now supported footnotes. `[^1]: simple footnote` is converted to `[^fn-nth-1]: simple footnote`.

but, currently, not supported multiline and inline footnote. This features will be implemented in the future, maybe using strategy pattern.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
