### PR TITLE
refactor: ConverterChain implementation for using composition instead of inheritance

### DIFF
--- a/src/core/Converter.ts
+++ b/src/core/Converter.ts
@@ -1,20 +1,5 @@
+export type Contents = string;
+
 export interface Converter {
-    setNext(next: Converter): Converter;
-    convert(input: string): string;
-}
-
-export abstract class AbstractConverter implements Converter {
-    private next: Converter;
-
-    setNext(next: Converter): Converter {
-        this.next = next;
-        return next;
-    }
-
-    convert(input: string): string {
-        if (this.next) {
-            return this.next.convert(input);
-        }
-        return input;
-    }
+    convert(input: Contents): Contents;
 }

--- a/src/core/ConverterChain.ts
+++ b/src/core/ConverterChain.ts
@@ -1,0 +1,25 @@
+import { Contents, Converter } from "./Converter";
+
+export class ConverterChain {
+    private converters: Converter[] = [];
+
+    private constructor() {
+    }
+
+    public static create(): ConverterChain {
+        return new ConverterChain();
+    }
+
+    public chaining(converter: Converter): ConverterChain {
+        this.converters.push(converter);
+        return this;
+    }
+
+    public converting(input: Contents): Contents {
+        let result = input;
+        for (const converter of this.converters) {
+            result = converter.convert(result);
+        }
+        return result;
+    }
+}

--- a/src/jekyll/CalloutConverter.ts
+++ b/src/jekyll/CalloutConverter.ts
@@ -1,11 +1,10 @@
-import { AbstractConverter } from "../core/Converter";
 import { replaceKeyword } from "../ObsidianCallout";
 import { ObsidianRegex } from "../ObsidianRegex";
+import { Converter } from "../core/Converter";
 
-export class CalloutConverter extends AbstractConverter {
+export class CalloutConverter implements Converter {
     convert(input: string): string {
-        const result = convertCalloutSyntaxToChirpy(input);
-        return super.convert(result);
+        return convertCalloutSyntaxToChirpy(input);
     }
 }
 

--- a/src/jekyll/FootnotesConverter.ts
+++ b/src/jekyll/FootnotesConverter.ts
@@ -1,13 +1,12 @@
-import { AbstractConverter } from "../core/Converter";
 import { ObsidianRegex } from "../ObsidianRegex";
+import { Converter } from "../core/Converter";
 
-export class FootnotesConverter extends AbstractConverter {
+export class FootnotesConverter implements Converter {
 
     convert(input: string): string {
-        const result = input.replace(ObsidianRegex.SIMPLE_FOOTNOTE, (match, key) => {
+        return input.replace(ObsidianRegex.SIMPLE_FOOTNOTE, (match, key) => {
             return `[^fn-nth-${key}]`;
         });
-        return super.convert(result);
     }
 
 }

--- a/src/jekyll/FrontMatterConverter.ts
+++ b/src/jekyll/FrontMatterConverter.ts
@@ -1,15 +1,14 @@
 import { parseFrontMatter } from "./parseFrontMatter";
 import { ObsidianRegex } from "../ObsidianRegex";
-import { AbstractConverter } from "../core/Converter";
+import { Converter } from "../core/Converter";
 
-export class FrontMatterConverter extends AbstractConverter {
+export class FrontMatterConverter implements Converter {
 
     private readonly fileName: string;
     private readonly resourcePath: string;
     private readonly isEnable: boolean;
 
     constructor(fileName: string, resourcePath: string, isEnable = false) {
-        super();
         this.fileName = fileName;
         this.resourcePath = resourcePath;
         this.isEnable = isEnable;
@@ -17,7 +16,7 @@ export class FrontMatterConverter extends AbstractConverter {
 
     convert(input: string): string {
         if (!this.isEnable) {
-            return super.convert(input);
+            return input;
         }
 
         const [frontMatter, body] = parseFrontMatter(input);
@@ -35,15 +34,13 @@ export class FrontMatterConverter extends AbstractConverter {
 
         frontMatter.image = convertImagePath(this.fileName, frontMatter.image, this.resourcePath);
 
-        const result = `---
+        return `---
 ${Object.entries(frontMatter)
             .map(([key, value]) => `${key}: ${value}`)
             .join("\n")}
 ---
 
 ${body}`;
-
-        return super.convert(result);
     }
 }
 

--- a/src/jekyll/ResourceLinkConverter.ts
+++ b/src/jekyll/ResourceLinkConverter.ts
@@ -1,9 +1,9 @@
-import { AbstractConverter } from "../core/Converter";
 import fs from "fs";
 import { ObsidianRegex } from "../ObsidianRegex";
 import { Notice } from "obsidian";
+import { Converter } from "../core/Converter";
 
-export class ResourceLinkConverter extends AbstractConverter {
+export class ResourceLinkConverter implements Converter {
     private readonly fileName: string;
     private readonly resourcePath: string;
     private readonly absolutePath: string;
@@ -11,7 +11,6 @@ export class ResourceLinkConverter extends AbstractConverter {
     private readonly relativeResourcePath: string;
 
     constructor(fileName: string, resourcePath: string, absolutePath: string, attachmentsFolder: string, relativeResourcePath: string) {
-        super();
         this.fileName = fileName;
         this.resourcePath = resourcePath;
         this.absolutePath = absolutePath;
@@ -43,9 +42,7 @@ export class ResourceLinkConverter extends AbstractConverter {
         const replacer = (match: string, p1: string, imageSize: string | undefined) =>
             `![image](/${this.relativeResourcePath}/${this.fileName}/${p1.replace(/\s/g, '-')})${convertImageSize(imageSize)}`;
 
-        const result = input.replace(ObsidianRegex.IMAGE_LINK, replacer);
-
-        return super.convert(result);
+        return input.replace(ObsidianRegex.IMAGE_LINK, replacer);
     }
 }
 

--- a/src/jekyll/WikiLinkConverter.ts
+++ b/src/jekyll/WikiLinkConverter.ts
@@ -1,9 +1,8 @@
-import { AbstractConverter } from "../core/Converter";
 import { ObsidianRegex } from "../ObsidianRegex";
+import { Converter } from "../core/Converter";
 
-export class WikiLinkConverter extends AbstractConverter {
+export class WikiLinkConverter implements Converter {
     convert(input: string): string {
-        const result = input.replace(ObsidianRegex.WIKI_LINK, (match, p1, p2) => (p2 ? p2 : p1));
-        return super.convert(result);
+        return input.replace(ObsidianRegex.WIKI_LINK, (match, p1, p2) => (p2 ? p2 : p1));
     }
 }

--- a/src/tests/ConverterChain.test.ts
+++ b/src/tests/ConverterChain.test.ts
@@ -1,0 +1,46 @@
+import { Contents, Converter } from "../core/Converter";
+import { ConverterChain } from "../core/ConverterChain";
+
+class TestRepeatConverter implements Converter {
+    convert(input: Contents): Contents {
+        return input + input;
+    }
+}
+
+class TestUpperConverter implements Converter {
+    convert(input: Contents): Contents {
+        return input.toUpperCase();
+    }
+}
+
+describe('ConverterChain', () => {
+    it('should created', () => {
+        const chain = ConverterChain.create();
+        expect(chain).toBeDefined();
+    });
+
+    it('should chaining', () => {
+        const chain = ConverterChain.create();
+        expect(chain.chaining(new TestRepeatConverter())).toBeDefined();
+    });
+
+    it('should converting', () => {
+        const chain = ConverterChain.create().chaining(new TestRepeatConverter());
+        expect(chain.converting("test")).toEqual("testtest");
+    });
+
+    it('should chaining multiple converters', () => {
+        const chain = ConverterChain.create()
+            .chaining(new TestRepeatConverter())
+            .chaining(new TestUpperConverter());
+        expect(chain.converting("test")).toEqual("TESTTEST");
+    });
+
+    it('should chaining multiple converters in reverse order', () => {
+        const chain = ConverterChain.create()
+            .chaining(new TestUpperConverter())
+            .chaining(new TestRepeatConverter());
+        expect(chain.converting("test")).toEqual("TESTTEST");
+    });
+
+});


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

```mermaid
classDiagram
class Converter
<<interface>> Converter
Converter: +setNext(Converter next) Converter
Converter: +convert(string input) string

class AbstractConverter {
  <<Abstract>>
  -Converter next
  +setNext(Converter next) Converter
  +convert(string input) string
}

Converter <|-- AbstractConverter

class FrontMatterConverter {
  -string filename
  -string resourcePath
  -bool isEnable
  +setNext(Converter next) Converter
  +convert(string input) string
}
AbstractConverter <-- FrontMatterConverter

class ResourceLinkConverter {
  -O2Plugin plugin
  -string title
  +setNext(Converter next) Converter
  +convert(string input) string
}
AbstractConverter <-- ResourceLinkConverter

class WikiLinkConverter {
 +setNext(Converter next) Converter
  +convert(string input) string
}
AbstractConverter <-- WikiLinkConverter

class CalloutConverter {
 +setNext(Converter next) Converter
  +convert(string input) string
}
AbstractConverter <-- CalloutConverter
```

## What is the new behavior?

Not functional change, just related to architecture.

```mermaid
classDiagram
class ConverterChain {
	-List~Converter~ converters
	+chaining(Converter converter) ConverterChain
	+converting(string input) string
}
class Converter {
	<<interface>>
	+convert(string input) string
}
ConverterChain*--Converter

class FrontMatterConverter {
  -string filename
  -string resourcePath
  -bool isEnable
  +convert(string input) string
}
Converter <|-- FrontMatterConverter

class ResourceLinkConverter {
  -O2Plugin plugin
  -string title
  +convert(string input) string
}
Converter <|-- ResourceLinkConverter

class WikiLinkConverter {
  +convert(string input) string
}
Converter <|-- WikiLinkConverter

class CalloutConverter {
  +convert(string input) string
}
Converter <|-- CalloutConverter
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
