### PR TITLE
feat: support image caption syntax

### DIFF
--- a/src/ObsidianRegex.ts
+++ b/src/ObsidianRegex.ts
@@ -1,5 +1,5 @@
 export const ObsidianRegex = {
-    ATTACHMENT_LINK: /!\[\[([^|\]]+)\.(\w+)\|?(\d*)]]/g,
+    ATTACHMENT_LINK: /!\[\[([^|\]]+)\.(\w+)\|?(\d*)]]\n{0,2}(_.*_)?/g,
     EMBEDDED_LINK: /!\[\[([\w\s-]+)[#^]*([\w\s]*)]]/g,
     WIKI_LINK: /(?<!!)\[\[([^|\]]+)\|?(.*)]]/g,
     CALLOUT: /> \[!(.*)].*?\n(>.*)/ig,

--- a/src/jekyll/ResourceLinkConverter.ts
+++ b/src/jekyll/ResourceLinkConverter.ts
@@ -39,8 +39,14 @@ export class ResourceLinkConverter implements Converter {
             );
         });
 
-        const replacer = (match: string, p1: string, suffix: string, imageSize: string | undefined, caption: string | undefined) =>
-            `![image](/${this.relativeResourcePath}/${this.fileName}/${p1.replace(/\s/g, '-')}.${suffix})${convertImageSize(imageSize)}${convertImageCaption(caption)}`;
+        const replacer = (match: string,
+                          contents: string,
+                          suffix: string,
+                          imageSize: string | undefined,
+                          caption: string | undefined) =>
+            `![image](/${this.relativeResourcePath}/${this.fileName}/${contents.replace(/\s/g, '-')}.${suffix})`
+            + `${convertImageSize(imageSize)}`
+            + `${convertImageCaption(caption)}`;
 
         return input.replace(ObsidianRegex.ATTACHMENT_LINK, replacer);
     }

--- a/src/jekyll/ResourceLinkConverter.ts
+++ b/src/jekyll/ResourceLinkConverter.ts
@@ -39,8 +39,8 @@ export class ResourceLinkConverter implements Converter {
             );
         });
 
-        const replacer = (match: string, p1: string, suffix: string, imageSize: string | undefined) =>
-            `![image](/${this.relativeResourcePath}/${this.fileName}/${p1.replace(/\s/g, '-')}.${suffix})${convertImageSize(imageSize)}`;
+        const replacer = (match: string, p1: string, suffix: string, imageSize: string | undefined, caption: string) =>
+            `![image](/${this.relativeResourcePath}/${this.fileName}/${p1.replace(/\s/g, '-')}.${suffix})${convertImageSize(imageSize)}${convertImageCaption(caption)}`;
 
         return input.replace(ObsidianRegex.ATTACHMENT_LINK, replacer);
     }
@@ -59,4 +59,11 @@ function convertImageSize(imageSize: string | undefined) {
         return '';
     }
     return `{ width="${imageSize}" }`;
+}
+
+function convertImageCaption(caption: string | undefined) {
+    if (caption === undefined || caption.length === 0) {
+        return '';
+    }
+    return `\n${caption}`;
 }

--- a/src/jekyll/ResourceLinkConverter.ts
+++ b/src/jekyll/ResourceLinkConverter.ts
@@ -39,7 +39,7 @@ export class ResourceLinkConverter implements Converter {
             );
         });
 
-        const replacer = (match: string, p1: string, suffix: string, imageSize: string | undefined, caption: string) =>
+        const replacer = (match: string, p1: string, suffix: string, imageSize: string | undefined, caption: string | undefined) =>
             `![image](/${this.relativeResourcePath}/${this.fileName}/${p1.replace(/\s/g, '-')}.${suffix})${convertImageSize(imageSize)}${convertImageCaption(caption)}`;
 
         return input.replace(ObsidianRegex.ATTACHMENT_LINK, replacer);

--- a/src/tests/ObsidianRegex.test.ts
+++ b/src/tests/ObsidianRegex.test.ts
@@ -14,12 +14,4 @@ describe('Image link', () => {
 
         expect(result).toEqual('test png');
     });
-
-    // TODO: not yet implemented
-    xit('should not match embedded syntax', () => {
-        const context = '![[Obsidian#What is Obsidian?]]';
-        const result = context.match(ObsidianRegex.ATTACHMENT_LINK);
-
-        expect(result).toBeNull();
-    });
 });

--- a/src/tests/ResourceLinkConverter.test.ts
+++ b/src/tests/ResourceLinkConverter.test.ts
@@ -43,3 +43,53 @@ describe("convert called", () => {
         expect(converter.convert(`![[test.png|100]]`)).toEqual(`![image](/assets/2023-01-01-post-mock/test.png){ width="100" }`);
     });
 });
+
+describe("image caption", () => {
+    const converter = new ResourceLinkConverter(
+        '2023-01-01-post-mock',
+        'assets',
+        'test',
+        'attachments',
+        'assets'
+    );
+
+    it('should remove blank line after attachments', () => {
+        const context = `
+![[test.png]]
+
+_This is a test image._
+`;
+
+        const result = converter.convert(context);
+        expect(result).toEqual(`
+![image](/assets/2023-01-01-post-mock/test.png)
+_This is a test image._
+`);
+    });
+
+    it('should insert next line if no more space after attachment', () => {
+        const context = `
+![[test.png]]_This is a test image._
+`;
+
+        const result = converter.convert(context);
+        expect(result).toEqual(`
+![image](/assets/2023-01-01-post-mock/test.png)
+_This is a test image._
+`);
+    });
+
+    it('should nothing if exist just one blank line', () => {
+        const context = `
+![[test.png]]
+_This is a test image._
+`;
+
+        const result = converter.convert(context);
+        expect(result).toEqual(`
+![image](/assets/2023-01-01-post-mock/test.png)
+_This is a test image._
+`);
+    });
+
+});


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: resolve #66 

## What is the new behavior?

Removes unnecessary lines to support image caption syntax of Jekyll chirpy. Insert the line if necessary.

**AS-IS**

```text
![[factory.png]]

_This is factory_

// or

![[factory.png]]
_This is factory_

// or
![[factory.png]]_This is factory_
```

**TO-BE**

```text
![image](/assets/img/<path>/factory.png)
_This is factory_
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
