### PR TITLE
feat: add jekyll relative resource path setting function

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -128,6 +128,7 @@ export class O2SettingTab extends PluginSettingTab {
     this.addBackupFolderSetting();
     this.addAttachmentsFolderSetting();
     this.addJekyllPathSetting();
+    this.addJekyllRelativeResourcePathSetting();
     this.containerEl.createEl('h2', {
       text: 'Features',
     });
@@ -148,7 +149,7 @@ export class O2SettingTab extends PluginSettingTab {
           await this.plugin.saveSettings();
         }));
   }
-  
+
   private enableAutoCreateFolderSetting() {
     const jekyllSetting = this.plugin.settings.jekyllSetting();
     new Setting(this.containerEl)
@@ -198,6 +199,20 @@ export class O2SettingTab extends PluginSettingTab {
         .setValue(jekyllSetting.jekyllPath)
         .onChange(async (value) => {
           jekyllSetting.jekyllPath = value;
+          await this.plugin.saveSettings();
+        }));
+  }
+
+  private addJekyllRelativeResourcePathSetting() {
+    const jekyllSetting = this.plugin.settings.jekyllSetting();
+    new Setting(this.containerEl)
+      .setName('Relative resource path')
+      .setDesc('The relative path where resources are stored.')
+      .addText(text => text
+        .setPlaceholder('Enter path')
+        .setValue(jekyllSetting.jekyllRelativeResourcePath)
+        .onChange(async (value) => {
+          jekyllSetting.jekyllRelativeResourcePath = value;
           await this.plugin.saveSettings();
         }));
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bugfixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

The current O2 Plugin only supports relative resource paths such as 'assets/img/<yyyy-MM-dd>-<title>'. 

However, in my case, I have organized my resources under 'assets/img/posts/<yyyy-MM-dd>-<title>'. 

To use this plugin, i need to have an option that allows for customization of the resource path.

## What is the new behavior?
I just add a new setting to custom relative resource path.

If you like this change, it might be worthwhile to consider a new name for the setting.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
