### PR TITLE
fix: modify convertImageSize function to return right image format

### DIFF
--- a/src/jekyll/ResourceLinkConverter.ts
+++ b/src/jekyll/ResourceLinkConverter.ts
@@ -67,7 +67,7 @@ function convertImageSize(width: string | undefined, height: string | undefined)
     return '';
   }
   if (height === undefined || height.length === 0) {
-    return `{ width="${width}" }`;
+    return `{: width="${width}" }`;
   }
   return `{: width="${width}" height="${height}" }`;
 }

--- a/src/tests/ResourceLinkConverter.test.ts
+++ b/src/tests/ResourceLinkConverter.test.ts
@@ -10,7 +10,7 @@ describe('extract image name', () => {
 
   it('should return image name array', () => {
     const context = `![[test.png]]
-        
+
         test
         ![[image.png]]
         `;
@@ -51,7 +51,7 @@ describe('resize image', () => {
   );
 
   it('should return converted attachments with width', () => {
-    expect(converter.convert(`![[test.png|100]]`)).toEqual(`![image](/assets/2023-01-01-post-mock/test.png){ width="100" }`);
+    expect(converter.convert(`![[test.png|100]]`)).toEqual(`![image](/assets/2023-01-01-post-mock/test.png){: width="100" }`);
   });
 
   it('should return converted attachments with width and height', () => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bugfixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/songkg7/o2/issues/332


## What is the new behavior?
We can get a format like {: width="{size}" } not { width="{size}" }.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
