### PR TITLE
fix: filenameConverter handles Korean correctly

### DIFF
--- a/src/jekyll/FilenameConverter.ts
+++ b/src/jekyll/FilenameConverter.ts
@@ -1,7 +1,8 @@
 export class FilenameConverter {
   convert(filename: string): string {
-    return filename.replace('.md', '')
+    return filename
+      .replace('.md', '')
       .replace(/\s/g, '-')
-      .replace(/[^a-zA-Z0-9-]/g, '');
+      .replace(/[^a-zA-Z0-9-\uAC00-\uD7A3]/g, '');
   }
 }

--- a/src/tests/FilenameConverter.test.ts
+++ b/src/tests/FilenameConverter.test.ts
@@ -13,14 +13,21 @@ describe('FilenameConverter', () => {
     expect(filename).toEqual('This-is-Obsidian');
   });
 
+  it('should convert Korean characters', () => {
+    const filename = filenameConverter.convert('이것은 옵시디언입니다.md');
+    expect(filename).toEqual('이것은-옵시디언입니다');
+  });
+
   it.each([
     ['This is Obsidian.md', 'This-is-Obsidian'],
     ['This is Obsidian!!.md', 'This-is-Obsidian'],
-    ['Obsidian, awesome note-taking tool.md', 'Obsidian-awesome-note-taking-tool'],
+    [
+      'Obsidian, awesome note-taking tool.md',
+      'Obsidian-awesome-note-taking-tool',
+    ],
     ['Obsidian(Markdown Editor).md', 'ObsidianMarkdown-Editor'],
   ])('should remove special characters', (filename, expected) => {
     const result = filenameConverter.convert(filename);
     expect(result).toEqual(expected);
   });
-
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bugfixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/songkg7/o2/issues/338


## What is the new behavior?

Now, O2 can convert post image folder name containing Korean Characters.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
