### PR TITLE
refactor: settings architecture

### DIFF
--- a/src/ResourceLinkConverter.ts
+++ b/src/ResourceLinkConverter.ts
@@ -2,23 +2,23 @@ import fs from 'fs';
 import { ObsidianRegex } from './core/ObsidianRegex';
 import { Notice } from 'obsidian';
 import { Converter } from './core/Converter';
-import JekyllSettings from './jekyll/settings/JekyllSettings';
 import { removeTempPrefix } from './FilenameConverter';
+import O2Plugin from './main';
 
 export const convertJekyllResourceLink = (
   input: string,
   fileName: string,
   absolutePath: string,
-  settings: JekyllSettings,
+  plugin: O2Plugin,
 ) => {
-  const resourcePath = `${settings.resourcePath}/${fileName}`;
+  const resourcePath = `${plugin.jekyll.resourcePath}/${fileName}`;
   const resourceNames = extractResourceNames(input);
   if (!(resourceNames === undefined || resourceNames.length === 0)) {
     fs.mkdirSync(resourcePath, { recursive: true });
   }
   resourceNames?.forEach((resourceName) => {
     fs.copyFile(
-      `${absolutePath}/${settings.attachmentsFolder}/${resourceName}`,
+      `${absolutePath}/${plugin.obsidianPathSettings.attachmentsFolder}/${resourceName}`,
       `${resourcePath}/${(resourceName.replace(/\s/g, '-'))}`,
       (err) => {
         if (err) {
@@ -37,7 +37,7 @@ export const convertJekyllResourceLink = (
                     height: string | undefined,
                     space: string | undefined,
                     caption: string | undefined) =>
-    `![image](/${settings.jekyllRelativeResourcePath}/${fileName}/${contents.replace(/\s/g, '-')}.${suffix})`
+    `![image](/${plugin.jekyll.jekyllRelativeResourcePath}/${fileName}/${contents.replace(/\s/g, '-')}.${suffix})`
     + `${convertImageSize(width, height)}`
     + `${convertImageCaption(caption)}`;
 

--- a/src/ResourceLinkConverter.ts
+++ b/src/ResourceLinkConverter.ts
@@ -3,47 +3,6 @@ import { ObsidianRegex } from './core/ObsidianRegex';
 import { Notice } from 'obsidian';
 import { Converter } from './core/Converter';
 import { removeTempPrefix } from './FilenameConverter';
-import O2Plugin from './main';
-
-export const convertJekyllResourceLink = (
-  input: string,
-  fileName: string,
-  absolutePath: string,
-  plugin: O2Plugin,
-) => {
-  const resourcePath = `${plugin.jekyll.resourcePath}/${fileName}`;
-  const resourceNames = extractResourceNames(input);
-  if (!(resourceNames === undefined || resourceNames.length === 0)) {
-    fs.mkdirSync(resourcePath, { recursive: true });
-  }
-  resourceNames?.forEach((resourceName) => {
-    fs.copyFile(
-      `${absolutePath}/${plugin.obsidianPathSettings.attachmentsFolder}/${resourceName}`,
-      `${resourcePath}/${(resourceName.replace(/\s/g, '-'))}`,
-      (err) => {
-        if (err) {
-          // ignore error
-          console.error(err);
-          new Notice(err.message);
-        }
-      },
-    );
-  });
-
-  const replacer = (match: string,
-                    contents: string,
-                    suffix: string,
-                    width: string | undefined,
-                    height: string | undefined,
-                    space: string | undefined,
-                    caption: string | undefined) =>
-    `![image](/${plugin.jekyll.jekyllRelativeResourcePath}/${fileName}/${contents.replace(/\s/g, '-')}.${suffix})`
-    + `${convertImageSize(width, height)}`
-    + `${convertImageCaption(caption)}`;
-
-  return input.replace(ObsidianRegex.ATTACHMENT_LINK, replacer);
-};
-
 
 export class ResourceLinkConverter implements Converter {
   private readonly fileName: string;

--- a/src/core/validation.ts
+++ b/src/core/validation.ts
@@ -1,34 +1,33 @@
 import O2Plugin from '../main';
 import { Notice } from 'obsidian';
-import { O2PluginSettings } from '../settings';
 
-export default async function validateSettings(plugin: O2Plugin, settings: O2PluginSettings) {
+export default async function validateSettings(plugin: O2Plugin) {
   const adapter = plugin.app.vault.adapter;
-  if (!await adapter.exists(settings.attachmentsFolder)) {
-    if (settings.isAutoCreateFolder) {
-      new Notice(`Auto create attachments folder: ${settings.attachmentsFolder}.`, 5000);
-      await adapter.mkdir(settings.attachmentsFolder);
+  if (!await adapter.exists(plugin.obsidianPathSettings.attachmentsFolder)) {
+    if (plugin.obsidianPathSettings.isAutoCreateFolder) {
+      new Notice(`Auto create attachments folder: ${plugin.obsidianPathSettings.attachmentsFolder}.`, 5000);
+      await adapter.mkdir(plugin.obsidianPathSettings.attachmentsFolder);
     } else {
-      new Notice(`Attachments folder ${settings.attachmentsFolder} does not exist.`, 5000);
-      throw new Error(`Attachments folder ${settings.attachmentsFolder} does not exist.`);
+      new Notice(`Attachments folder ${plugin.obsidianPathSettings.attachmentsFolder} does not exist.`, 5000);
+      throw new Error(`Attachments folder ${plugin.obsidianPathSettings.attachmentsFolder} does not exist.`);
     }
   }
-  if (!await adapter.exists(settings.readyFolder)) {
-    if (settings.isAutoCreateFolder) {
-      new Notice(`Auto create ready folder: ${settings.readyFolder}.`, 5000);
-      await adapter.mkdir(settings.readyFolder);
+  if (!await adapter.exists(plugin.obsidianPathSettings.readyFolder)) {
+    if (plugin.obsidianPathSettings.isAutoCreateFolder) {
+      new Notice(`Auto create ready folder: ${plugin.obsidianPathSettings.readyFolder}.`, 5000);
+      await adapter.mkdir(plugin.obsidianPathSettings.readyFolder);
     } else {
-      new Notice(`Ready folder ${settings.readyFolder} does not exist.`, 5000);
-      throw new Error(`Ready folder ${settings.readyFolder} does not exist.`);
+      new Notice(`Ready folder ${plugin.obsidianPathSettings.readyFolder} does not exist.`, 5000);
+      throw new Error(`Ready folder ${plugin.obsidianPathSettings.readyFolder} does not exist.`);
     }
   }
-  if (!await adapter.exists(settings.achieveFolder)) {
-    if (settings.isAutoCreateFolder) {
-      new Notice(`Auto create backup folder: ${settings.achieveFolder}.`, 5000);
-      await adapter.mkdir(settings.achieveFolder);
+  if (!await adapter.exists(plugin.obsidianPathSettings.archiveFolder)) {
+    if (plugin.obsidianPathSettings.isAutoCreateFolder) {
+      new Notice(`Auto create backup folder: ${plugin.obsidianPathSettings.archiveFolder}.`, 5000);
+      await adapter.mkdir(plugin.obsidianPathSettings.archiveFolder);
     } else {
-      new Notice(`Backup folder ${settings.achieveFolder} does not exist.`, 5000);
-      throw new Error(`Backup folder ${settings.achieveFolder} does not exist.`);
+      new Notice(`Backup folder ${plugin.obsidianPathSettings.archiveFolder} does not exist.`, 5000);
+      throw new Error(`Backup folder ${plugin.obsidianPathSettings.archiveFolder} does not exist.`);
     }
   }
 }

--- a/src/core/validation.ts
+++ b/src/core/validation.ts
@@ -1,7 +1,7 @@
 import O2Plugin from '../main';
 import { Notice } from 'obsidian';
 
-export default async function validateSettings(plugin: O2Plugin) {
+export default async (plugin: O2Plugin) => {
   const adapter = plugin.app.vault.adapter;
   if (!await adapter.exists(plugin.obsidianPathSettings.attachmentsFolder)) {
     if (plugin.obsidianPathSettings.isAutoCreateFolder) {
@@ -30,5 +30,5 @@ export default async function validateSettings(plugin: O2Plugin) {
       throw new Error(`Backup folder ${plugin.obsidianPathSettings.archiveFolder} does not exist.`);
     }
   }
-}
+};
 

--- a/src/docusaurus/docusaurus.ts
+++ b/src/docusaurus/docusaurus.ts
@@ -64,11 +64,9 @@ export const convertToDocusaurus = async (plugin: O2Plugin) => {
         new Notice('Converted to Docusaurus successfully.', 5000);
       });
 
-    plugin.app.fileManager.ge;
-
     // move files to docusaurus folder
     await moveFiles(
-      `${vaultAbsolutePath(plugin)}/${plugin.docusaurus.readyFolder}`,
+      `${vaultAbsolutePath(plugin)}/${plugin.obsidianPathSettings.readyFolder}`,
       plugin.docusaurus.targetPath(),
       plugin.docusaurus.pathReplacer,
       parseLocalDate(publishedDate),

--- a/src/docusaurus/settings/DocusaurusSettings.ts
+++ b/src/docusaurus/settings/DocusaurusSettings.ts
@@ -2,13 +2,9 @@ import { O2PluginSettings } from '../../settings';
 import { DateExtractionPattern } from '../DateExtractionPattern';
 
 export default class DocusaurusSettings implements O2PluginSettings {
-  attachmentsFolder: string;
-  readyFolder: string;
-  achieveFolder: string;
   docusaurusPath: string;
   isAutoCreateFolder: boolean;
   dateExtractionPattern: string;
-  isAutoAchieve: boolean;
 
   targetPath(): string {
     return `${this.docusaurusPath}/blog`;

--- a/src/docusaurus/settings/DocusaurusSettings.ts
+++ b/src/docusaurus/settings/DocusaurusSettings.ts
@@ -3,7 +3,6 @@ import { DateExtractionPattern } from '../DateExtractionPattern';
 
 export default class DocusaurusSettings implements O2PluginSettings {
   docusaurusPath: string;
-  isAutoCreateFolder: boolean;
   dateExtractionPattern: string;
 
   targetPath(): string {

--- a/src/jekyll/chirpy.ts
+++ b/src/jekyll/chirpy.ts
@@ -11,7 +11,6 @@ import { CommentsConverter } from '../CommentsConverter';
 import { EmbedsConverter } from '../EmbedsConverter';
 import { convertCurlyBrace, CurlyBraceConverter } from '../CurlyBraceConverter';
 import JekyllSettings from './settings/JekyllSettings';
-import validateSettings from '../core/validation';
 import { convertFileName } from '../FilenameConverter';
 import { Contents } from '../core/Converter';
 
@@ -54,8 +53,6 @@ export const convertToChirpyV2 = async (plugin: O2Plugin) => {
 
 export async function convertToChirpy(plugin: O2Plugin) {
   const settings = plugin.jekyll as JekyllSettings;
-  // validation
-  await validateSettings(plugin, settings);
   try {
     const markdownFiles = await copyMarkdownFile(plugin);
     for (const file of markdownFiles) {

--- a/src/jekyll/chirpy.ts
+++ b/src/jekyll/chirpy.ts
@@ -1,55 +1,17 @@
 import O2Plugin from '../main';
 import { WikiLinkConverter } from '../WikiLinkConverter';
-import { convertJekyllResourceLink, ResourceLinkConverter } from '../ResourceLinkConverter';
+import { ResourceLinkConverter } from '../ResourceLinkConverter';
 import { Notice } from 'obsidian';
 import { CalloutConverter } from '../CalloutConverter';
-import { convertFrontMatter, FrontMatterConverter } from '../FrontMatterConverter';
+import { FrontMatterConverter } from '../FrontMatterConverter';
 import { copyMarkdownFile, moveFiles, vaultAbsolutePath } from '../utils';
 import { FootnotesConverter } from '../FootnotesConverter';
 import { ConverterChain } from '../core/ConverterChain';
 import { CommentsConverter } from '../CommentsConverter';
 import { EmbedsConverter } from '../EmbedsConverter';
-import { convertCurlyBrace, CurlyBraceConverter } from '../CurlyBraceConverter';
+import { CurlyBraceConverter } from '../CurlyBraceConverter';
 import JekyllSettings from './settings/JekyllSettings';
 import { convertFileName } from '../FilenameConverter';
-import { Contents } from '../core/Converter';
-
-// WIP
-// TODO: implement this function
-export const convertToChirpyV2 = async (plugin: O2Plugin) => {
-  const settings = plugin.jekyll as JekyllSettings;
-  const markdownFiles = await copyMarkdownFile(plugin);
-  for (const file of markdownFiles) {
-    const fileName = convertFileName(file.name);
-    const contents: Contents = await plugin.app.vault.read(file);
-
-    const result =
-      convertCurlyBrace(
-        settings.isEnableCurlyBraceConvertMode,
-        convertFrontMatter(
-          convertJekyllResourceLink(
-            contents,
-            fileName,
-            vaultAbsolutePath(plugin),
-            plugin
-          ),
-        ),
-      );
-
-    await plugin.app.vault.modify(file, result)
-      .then(() => {
-        new Notice('Converted to Chirpy successfully.', 5000);
-      });
-
-    // move files to chirpy folder
-    await moveFiles(
-      `${vaultAbsolutePath(plugin)}/${plugin.obsidianPathSettings.readyFolder}`,
-      settings.targetPath(),
-      settings.pathReplacer,
-    )
-      .then(() => new Notice('Moved files to Chirpy successfully.', 5000));
-  }
-};
 
 export async function convertToChirpy(plugin: O2Plugin) {
   const settings = plugin.jekyll as JekyllSettings;

--- a/src/jekyll/chirpy.ts
+++ b/src/jekyll/chirpy.ts
@@ -32,7 +32,7 @@ export const convertToChirpyV2 = async (plugin: O2Plugin) => {
             contents,
             fileName,
             vaultAbsolutePath(plugin),
-            settings,
+            plugin
           ),
         ),
       );

--- a/src/jekyll/chirpy.ts
+++ b/src/jekyll/chirpy.ts
@@ -44,7 +44,7 @@ export const convertToChirpyV2 = async (plugin: O2Plugin) => {
 
     // move files to chirpy folder
     await moveFiles(
-      `${vaultAbsolutePath(plugin)}/${settings.readyFolder}`,
+      `${vaultAbsolutePath(plugin)}/${plugin.obsidianPathSettings.readyFolder}`,
       settings.targetPath(),
       settings.pathReplacer,
     )
@@ -70,7 +70,7 @@ export async function convertToChirpy(plugin: O2Plugin) {
         fileName,
         settings.resourcePath(),
         vaultAbsolutePath(plugin),
-        settings.attachmentsFolder,
+        plugin.obsidianPathSettings.attachmentsFolder,
         settings.jekyllRelativeResourcePath,
       );
       const curlyBraceConverter = new CurlyBraceConverter(
@@ -89,7 +89,7 @@ export async function convertToChirpy(plugin: O2Plugin) {
 
       await plugin.app.vault.modify(file, result);
       await moveFiles(
-        `${vaultAbsolutePath(plugin)}/${settings.readyFolder}`,
+        `${vaultAbsolutePath(plugin)}/${plugin.obsidianPathSettings.readyFolder}`,
         settings.targetPath(),
         settings.pathReplacer,
       )

--- a/src/jekyll/settings/JekyllSettings.ts
+++ b/src/jekyll/settings/JekyllSettings.ts
@@ -1,10 +1,6 @@
 import { O2PluginSettings } from '../../settings';
 
 export default class JekyllSettings implements O2PluginSettings {
-  attachmentsFolder: string;
-  readyFolder: string;
-  achieveFolder: string;
-  isAutoAchieve: boolean;
   private _jekyllPath: string;
   private _jekyllRelativeResourcePath: string;
   private _isAutoCreateFolder: boolean;
@@ -18,9 +14,6 @@ export default class JekyllSettings implements O2PluginSettings {
   private _isEnableUpdateFrontmatterTimeOnEdit: boolean;
 
   constructor() {
-    this.attachmentsFolder = 'attachments';
-    this.readyFolder = 'ready';
-    this.achieveFolder = 'backup';
     this._jekyllPath = '';
     this._jekyllRelativeResourcePath = 'assets/img';
     this._isAutoCreateFolder = false;

--- a/src/jekyll/settings/JekyllSettings.ts
+++ b/src/jekyll/settings/JekyllSettings.ts
@@ -3,7 +3,6 @@ import { O2PluginSettings } from '../../settings';
 export default class JekyllSettings implements O2PluginSettings {
   private _jekyllPath: string;
   private _jekyllRelativeResourcePath: string;
-  private _isAutoCreateFolder: boolean;
   pathReplacer(year: string, month: string, day: string, title: string): string {
     return `${year}-${month}-${day}-${title}.md`;
   }
@@ -16,7 +15,6 @@ export default class JekyllSettings implements O2PluginSettings {
   constructor() {
     this._jekyllPath = '';
     this._jekyllRelativeResourcePath = 'assets/img';
-    this._isAutoCreateFolder = false;
   }
 
   get jekyllPath(): string {
@@ -57,14 +55,6 @@ export default class JekyllSettings implements O2PluginSettings {
 
   set isEnableUpdateFrontmatterTimeOnEdit(value: boolean) {
     this._isEnableUpdateFrontmatterTimeOnEdit = value;
-  }
-
-  get isAutoCreateFolder(): boolean {
-    return this._isAutoCreateFolder;
-  }
-
-  set isAutoCreateFolder(value: boolean) {
-    this._isAutoCreateFolder = value;
   }
 
   targetPath(): string {

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,7 +22,15 @@ export default class O2Plugin extends Plugin {
           if (checking) {
             return true;
           }
-          o2ConversionCommand(this).then(() => new Notice('Converted to successfully.', 5000));
+          o2ConversionCommand(this)
+            .then(() => new Notice('Converted to successfully.', 5000))
+            .finally(() => {
+              // archive
+              if (this.obsidianPathSettings.isAutoArchive) {
+                // move files to archive
+
+              }
+            });
         }
       },
     });

--- a/src/main.ts
+++ b/src/main.ts
@@ -48,9 +48,11 @@ export default class O2Plugin extends Plugin {
   }
 
   async saveSettings() {
-    await this.saveData(this.obsidianPathSettings);
-    await this.saveData(this.jekyll);
-    await this.saveData(this.docusaurus);
+    await this.saveData({
+      obsidianPathSettings: this.obsidianPathSettings,
+      jekyll: this.jekyll,
+      docusaurus: this.docusaurus,
+    });
   }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import { Notice, Plugin } from 'obsidian';
-import { O2SettingTab } from './settings';
+import { O2SettingTab, ObsidianPathSettings } from './settings';
 import JekyllSettings from './jekyll/settings/JekyllSettings';
 import DocusaurusSettings from './docusaurus/settings/DocusaurusSettings';
 import { convertToChirpy } from './jekyll/chirpy';
@@ -7,6 +7,7 @@ import { convertToDocusaurus } from './docusaurus/docusaurus';
 import { cleanUp } from './utils';
 
 export default class O2Plugin extends Plugin {
+  obsidianPathSettings: ObsidianPathSettings;
   jekyll: JekyllSettings;
   docusaurus: DocusaurusSettings;
 
@@ -34,6 +35,7 @@ export default class O2Plugin extends Plugin {
   }
 
   async loadSettings() {
+    this.obsidianPathSettings = Object.assign(new ObsidianPathSettings(), await this.loadData());
     this.jekyll = Object.assign(new JekyllSettings(), await this.loadData());
     this.docusaurus = Object.assign(new DocusaurusSettings(), await this.loadData());
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,8 @@ import JekyllSettings from './jekyll/settings/JekyllSettings';
 import DocusaurusSettings from './docusaurus/settings/DocusaurusSettings';
 import { convertToChirpy } from './jekyll/chirpy';
 import { convertToDocusaurus } from './docusaurus/docusaurus';
-import { cleanUp } from './utils';
+import { archiving, cleanUp } from './utils';
+import validateSettings from './core/validation';
 
 export default class O2Plugin extends Plugin {
   obsidianPathSettings: ObsidianPathSettings;
@@ -24,11 +25,12 @@ export default class O2Plugin extends Plugin {
           }
           o2ConversionCommand(this)
             .then(() => new Notice('Converted to successfully.', 5000))
-            .finally(() => {
+            .then(() => {
               // archive
               if (this.obsidianPathSettings.isAutoArchive) {
                 // move files to archive
-
+                console.log('archiving');
+                archiving(this);
               }
             });
         }
@@ -55,6 +57,7 @@ export default class O2Plugin extends Plugin {
 }
 
 const o2ConversionCommand = async (plugin: O2Plugin) => {
+  await validateSettings(plugin);
   if (plugin.jekyll.afterPropertiesSet()) {
     await convertToChirpy(plugin)
       .finally(() => cleanUp(plugin));

--- a/src/main.ts
+++ b/src/main.ts
@@ -48,6 +48,7 @@ export default class O2Plugin extends Plugin {
   }
 
   async saveSettings() {
+    await this.saveData(this.obsidianPathSettings);
     await this.saveData(this.jekyll);
     await this.saveData(this.docusaurus);
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,7 +29,6 @@ export default class O2Plugin extends Plugin {
               // archive
               if (this.obsidianPathSettings.isAutoArchive) {
                 // move files to archive
-                console.log('archiving');
                 archiving(this);
               }
             });

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,9 +26,7 @@ export default class O2Plugin extends Plugin {
           o2ConversionCommand(this)
             .then(() => new Notice('Converted to successfully.', 5000))
             .then(() => {
-              // archive
               if (this.obsidianPathSettings.isAutoArchive) {
-                // move files to archive
                 archiving(this);
               }
             });

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -41,6 +41,7 @@ export class O2SettingTab extends PluginSettingTab {
     this.addReadyFolderSetting();
     this.addAchieveFolderSetting();
     this.addAttachmentsFolderSetting();
+    this.enableAutoArchiveSetting();
 
     // jekyll settings
     this.containerEl.createEl('h2', {
@@ -62,7 +63,6 @@ export class O2SettingTab extends PluginSettingTab {
     this.enableCurlyBraceSetting();
     this.enableUpdateFrontmatterTimeOnEditSetting();
     this.enableAutoCreateFolderSetting();
-    // this.enableAutoAchieveSetting();
   }
 
   private enableUpdateFrontmatterTimeOnEditSetting() {
@@ -201,7 +201,7 @@ export class O2SettingTab extends PluginSettingTab {
       });
   }
 
-  private enableAutoAchieveSetting() {
+  private enableAutoArchiveSetting() {
     new Setting(this.containerEl)
       .setName('Auto achieve')
       .setDesc('Automatically move files to achieve folder after converting.')

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -39,7 +39,7 @@ export class O2SettingTab extends PluginSettingTab {
       text: 'Path Settings',
     });
     this.addReadyFolderSetting();
-    this.addAchieveFolderSetting();
+    this.addArchiveFolderSetting();
     this.addAttachmentsFolderSetting();
     this.enableAutoArchiveSetting();
 
@@ -157,7 +157,7 @@ export class O2SettingTab extends PluginSettingTab {
         }));
   }
 
-  private addAchieveFolderSetting() {
+  private addArchiveFolderSetting() {
     new Setting(this.containerEl)
       .setName('Folder to Archive notes in')
       .setDesc('Where the notes will be archived after conversion.')
@@ -203,8 +203,8 @@ export class O2SettingTab extends PluginSettingTab {
 
   private enableAutoArchiveSetting() {
     new Setting(this.containerEl)
-      .setName('Auto achieve')
-      .setDesc('Automatically move files to achieve folder after converting.')
+      .setName('Auto archive')
+      .setDesc('Automatically move files to archive folder after converting.')
       .addToggle(toggle => toggle
         .setValue(this.plugin.obsidianPathSettings.isAutoArchive)
         .onChange(async (value) => {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -9,11 +9,10 @@ export class ObsidianPathSettings {
   archiveFolder: string = 'archive';
   attachmentsFolder: string = 'attachments';
   isAutoArchive: boolean = false;
+  isAutoCreateFolder: boolean = false;
 }
 
 export interface O2PluginSettings {
-  isAutoCreateFolder: boolean;
-
   targetPath(): string;
 
   resourcePath(): string;
@@ -80,14 +79,13 @@ export class O2SettingTab extends PluginSettingTab {
   }
 
   private enableAutoCreateFolderSetting() {
-    const jekyllSetting = this.plugin.jekyll as JekyllSettings;
     new Setting(this.containerEl)
       .setName('Auto create folders')
       .setDesc('Automatically create necessary folders if they do not exist.')
       .addToggle(toggle => toggle
-        .setValue(jekyllSetting.isAutoCreateFolder)
+        .setValue(this.plugin.obsidianPathSettings.isAutoCreateFolder)
         .onChange(async (value) => {
-          jekyllSetting.isAutoCreateFolder = value;
+          this.plugin.obsidianPathSettings.isAutoCreateFolder = value;
           await this.plugin.saveSettings();
         }));
   }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -35,12 +35,20 @@ export class O2SettingTab extends PluginSettingTab {
     this.containerEl.createEl('h1', {
       text: 'Settings for O2 plugin',
     });
+
     this.containerEl.createEl('h2', {
       text: 'Path Settings',
     });
     this.addReadyFolderSetting();
     this.addArchiveFolderSetting();
     this.addAttachmentsFolderSetting();
+
+    this.containerEl.createEl('h2', {
+      text: 'Features',
+    });
+    this.enableCurlyBraceSetting();
+    this.enableUpdateFrontmatterTimeOnEditSetting();
+    this.enableAutoCreateFolderSetting();
     this.enableAutoArchiveSetting();
 
     // jekyll settings
@@ -56,13 +64,6 @@ export class O2SettingTab extends PluginSettingTab {
     });
     this.addDocusaurusPathSetting();
     this.dateExtractionPatternSetting();
-
-    this.containerEl.createEl('h2', {
-      text: 'Features',
-    });
-    this.enableCurlyBraceSetting();
-    this.enableUpdateFrontmatterTimeOnEditSetting();
-    this.enableAutoCreateFolderSetting();
   }
 
   private enableUpdateFrontmatterTimeOnEditSetting() {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -4,12 +4,15 @@ import JekyllSettings from './jekyll/settings/JekyllSettings';
 import DocusaurusSettings from './docusaurus/settings/DocusaurusSettings';
 import { DateExtractionPattern } from './docusaurus/DateExtractionPattern';
 
+export class ObsidianPathSettings {
+  readyFolder: string = 'ready';
+  archiveFolder: string = 'archive';
+  attachmentsFolder: string = 'attachments';
+  isAutoArchive: boolean = false;
+}
+
 export interface O2PluginSettings {
   isAutoCreateFolder: boolean;
-  attachmentsFolder: string;
-  readyFolder: string;
-  achieveFolder: string;
-  isAutoAchieve: boolean;
 
   targetPath(): string;
 
@@ -136,9 +139,9 @@ export class O2SettingTab extends PluginSettingTab {
       .setDesc('Where the attachments will be stored.')
       .addText(text => text
         .setPlaceholder('Enter folder name')
-        .setValue(this.plugin.jekyll.attachmentsFolder)
+        .setValue(this.plugin.obsidianPathSettings.attachmentsFolder)
         .onChange(async (value) => {
-          this.plugin.jekyll.attachmentsFolder = value;
+          this.plugin.obsidianPathSettings.attachmentsFolder = value;
           await this.plugin.saveSettings();
         }));
   }
@@ -149,11 +152,9 @@ export class O2SettingTab extends PluginSettingTab {
       .setDesc('Where the notes will be converted to another syntax.')
       .addText(text => text
         .setPlaceholder('Enter folder name')
-        .setValue(this.plugin.jekyll.readyFolder)
-        .setValue(this.plugin.docusaurus.readyFolder) // FIXME: global settings for path
+        .setValue(this.plugin.obsidianPathSettings.readyFolder)
         .onChange(async (value) => {
-          this.plugin.jekyll.readyFolder = value;
-          this.plugin.docusaurus.readyFolder = value;
+          this.plugin.obsidianPathSettings.readyFolder = value;
           await this.plugin.saveSettings();
         }));
   }
@@ -164,11 +165,9 @@ export class O2SettingTab extends PluginSettingTab {
       .setDesc('Where the notes will be archived after conversion.')
       .addText(text => text
         .setPlaceholder('Enter folder name')
-        .setValue(this.plugin.jekyll.achieveFolder)
-        .setValue(this.plugin.docusaurus.achieveFolder)
+        .setValue(this.plugin.obsidianPathSettings.archiveFolder)
         .onChange(async (value) => {
-          this.plugin.jekyll.achieveFolder = value;
-          this.plugin.docusaurus.achieveFolder = value;
+          this.plugin.obsidianPathSettings.archiveFolder = value;
           await this.plugin.saveSettings();
         }));
   }
@@ -209,11 +208,9 @@ export class O2SettingTab extends PluginSettingTab {
       .setName('Auto achieve')
       .setDesc('Automatically move files to achieve folder after converting.')
       .addToggle(toggle => toggle
-        .setValue(this.plugin.jekyll.isAutoAchieve)
-        .setValue(this.plugin.docusaurus.isAutoAchieve)
+        .setValue(this.plugin.obsidianPathSettings.isAutoArchive)
         .onChange(async (value) => {
-          this.plugin.jekyll.isAutoAchieve = value;
-          this.plugin.docusaurus.isAutoAchieve = value;
+          this.plugin.obsidianPathSettings.isAutoArchive = value;
           await this.plugin.saveSettings();
         }));
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,7 @@ import { FileSystemAdapter, Notice, TFile } from 'obsidian';
 import { Temporal } from '@js-temporal/polyfill';
 import fs from 'fs';
 import path from 'path';
-import { O2PluginSettings } from './settings';
+import { ObsidianPathSettings } from './settings';
 import { DateExtractionPattern } from './docusaurus/DateExtractionPattern';
 
 export const TEMP_PREFIX = 'o2-temp.' as const;
@@ -41,12 +41,12 @@ export const copyMarkdownFile = async (plugin: O2Plugin): Promise<TFile[]> => {
 
 export const getFilesInReady = (plugin: O2Plugin): TFile[] =>
   plugin.app.vault.getMarkdownFiles()
-    .filter((file: TFile) => file.path.startsWith(plugin.jekyll.readyFolder));
+    .filter((file: TFile) => file.path.startsWith(plugin.obsidianPathSettings.readyFolder));
 
 export async function backupOriginalNotes(plugin: O2Plugin) {
   const readyFiles = getFilesInReady(plugin);
-  const backupFolder = plugin.jekyll.achieveFolder;
-  const readyFolder = plugin.jekyll.readyFolder;
+  const backupFolder = plugin.obsidianPathSettings.archiveFolder;
+  const readyFolder = plugin.obsidianPathSettings.readyFolder;
   readyFiles.forEach((file: TFile) => {
     return plugin.app.vault.copy(file, file.path.replace(readyFolder, backupFolder));
   });
@@ -83,15 +83,15 @@ export const copy = (
     });
 };
 
-export const achieve = async (plugin: O2Plugin, settings: O2PluginSettings) => {
-  if (!settings.isAutoAchieve) {
+export const archiving = async (plugin: O2Plugin, settings: ObsidianPathSettings) => {
+  if (!settings.isAutoArchive) {
     return;
   }
 
   // move files to achieve folder
   const readyFiles = getFilesInReady(plugin);
   readyFiles.forEach((file: TFile) => {
-    return plugin.app.vault.copy(file, file.path.replace(settings.readyFolder, settings.achieveFolder));
+    return plugin.app.vault.copy(file, file.path.replace(settings.readyFolder, settings.archiveFolder));
   });
 };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,6 @@ import { FileSystemAdapter, Notice, TFile } from 'obsidian';
 import { Temporal } from '@js-temporal/polyfill';
 import fs from 'fs';
 import path from 'path';
-import { ObsidianPathSettings } from './settings';
 import { DateExtractionPattern } from './docusaurus/DateExtractionPattern';
 
 export const TEMP_PREFIX = 'o2-temp.' as const;
@@ -83,15 +82,16 @@ export const copy = (
     });
 };
 
-export const archiving = async (plugin: O2Plugin, settings: ObsidianPathSettings) => {
-  if (!settings.isAutoArchive) {
+export const archiving = async (plugin: O2Plugin) => {
+  if (!plugin.obsidianPathSettings.isAutoArchive) {
     return;
   }
 
-  // move files to achieve folder
+  // move files to archive folder
   const readyFiles = getFilesInReady(plugin);
+  console.log(readyFiles);
   readyFiles.forEach((file: TFile) => {
-    return plugin.app.vault.copy(file, file.path.replace(settings.readyFolder, settings.archiveFolder));
+    return plugin.app.vault.copy(file, file.path.replace(plugin.obsidianPathSettings.readyFolder, plugin.obsidianPathSettings.archiveFolder));
   });
 };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -42,15 +42,6 @@ export const getFilesInReady = (plugin: O2Plugin): TFile[] =>
   plugin.app.vault.getMarkdownFiles()
     .filter((file: TFile) => file.path.startsWith(plugin.obsidianPathSettings.readyFolder));
 
-export async function backupOriginalNotes(plugin: O2Plugin) {
-  const readyFiles = getFilesInReady(plugin);
-  const backupFolder = plugin.obsidianPathSettings.archiveFolder;
-  const readyFolder = plugin.obsidianPathSettings.readyFolder;
-  readyFiles.forEach((file: TFile) => {
-    return plugin.app.vault.copy(file, file.path.replace(readyFolder, backupFolder));
-  });
-}
-
 const copyFile = (sourceFilePath: string, targetFilePath: string) => {
   // if directory not exist create it
   const targetDirectory = path.dirname(targetFilePath);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -89,7 +89,6 @@ export const archiving = async (plugin: O2Plugin) => {
 
   // move files to archive folder
   const readyFiles = getFilesInReady(plugin);
-  console.log(readyFiles);
   readyFiles.forEach((file: TFile) => {
     return plugin.app.vault.copy(file, file.path.replace(plugin.obsidianPathSettings.readyFolder, plugin.obsidianPathSettings.archiveFolder));
   });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -90,7 +90,7 @@ export const archiving = async (plugin: O2Plugin) => {
   // move files to archive folder
   const readyFiles = getFilesInReady(plugin);
   readyFiles.forEach((file: TFile) => {
-    return plugin.app.vault.copy(file, file.path.replace(plugin.obsidianPathSettings.readyFolder, plugin.obsidianPathSettings.archiveFolder));
+    plugin.app.fileManager.renameFile(file, file.path.replace(plugin.obsidianPathSettings.readyFolder, plugin.obsidianPathSettings.archiveFolder));
   });
 };
 


### PR DESCRIPTION
# Pull Request

## Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bugfixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
<!-- If this is a PR that resolves the issue, please include the `close` or `resolve` keyword -->

Issue Number: N/A


## What is the new behavior?

- Delete duplicate settings and make clear.
- Auto Archive option for 1.x compativility.
- fix some typos.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Unified settings structure by replacing references to `JekyllSettings` and `DocusaurusSettings` with `O2Plugin`.
  - Simplified settings by removing folder-related properties and merging them into `ObsidianPathSettings`.
  - Enhanced the `O2Plugin` class to directly manage path settings and validation.

- **New Features**
  - Introduced new settings options like `isEnableUpdateFrontmatterTimeOnEdit` for improved customization.

- **Chores**
  - Updated function signatures and removed obsolete methods for streamlined codebase maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->