### PR TITLE
feat: Add support for multiple authors and update settings UI

### DIFF
--- a/src/AuthorStrategyFactory.ts
+++ b/src/AuthorStrategyFactory.ts
@@ -1,0 +1,25 @@
+import { PlatformType } from './enums/PlatformType';
+import {
+  AuthorStrategy,
+
+
+} from './strategies/authors/AuthorStrategy';
+import { DocusaurusAuthorStrategy } from './strategies/authors/DocusaurusAuthorStrategy';
+import { JekyllAuthorStrategy } from './strategies/authors/JekyllAuthorStrategy';
+import { DefaultAuthorStrategy } from './strategies/authors/DefaultAuthorStrategy';
+
+export class AuthorStrategyFactory {
+  static createStrategy(platform: PlatformType, authors: string): AuthorStrategy {
+    if (!authors) {
+      return new DefaultAuthorStrategy();
+    }
+    switch (platform) {
+      case PlatformType.Jekyll:
+        return new JekyllAuthorStrategy();
+      case PlatformType.Docusaurus:
+        return new DocusaurusAuthorStrategy();
+      default:
+        return new DefaultAuthorStrategy();
+    }
+  }
+}

--- a/src/docusaurus/docusaurus.ts
+++ b/src/docusaurus/docusaurus.ts
@@ -6,7 +6,8 @@ import { convertFootnotes } from '../FootnotesConverter';
 import { convertDocusaurusCallout } from '../CalloutConverter';
 import { convertComments } from '../CommentsConverter';
 import { Notice, TFile } from 'obsidian';
-import { convertFrontMatter } from '../FrontMatterConverter';
+import { FrontMatterConverter } from '../FrontMatterConverter';
+import DocusaurusSettings from './settings/DocusaurusSettings';
 
 const markPublished = async (plugin: O2Plugin) => {
   const filesInReady = getFilesInReady(plugin);
@@ -39,11 +40,21 @@ const checkPublished = async (plugin: O2Plugin, file: TFile) => {
 };
 
 export const convertToDocusaurus = async (plugin: O2Plugin) => {
+  const settings = plugin.docusaurus as DocusaurusSettings;
   // get file name in ready folder
   const markdownFiles = await copyMarkdownFile(plugin);
 
   for (const file of markdownFiles) {
     const publishedDate = await checkPublished(plugin, file);
+
+    const frontMatterConverter = new FrontMatterConverter(
+      file.name,
+      settings.resourcePath(),
+      false,
+      false,
+      settings.authors,
+      settings.platform,
+    );
 
     const contents: Contents = await plugin.app.vault.read(file);
     const result =
@@ -51,9 +62,7 @@ export const convertToDocusaurus = async (plugin: O2Plugin) => {
         convertDocusaurusCallout(
           convertFootnotes(
             convertWikiLink(
-              convertFrontMatter(
-                contents,
-              ),
+              frontMatterConverter.convert(contents),
             ),
           ),
         ),

--- a/src/docusaurus/settings/DocusaurusSettings.ts
+++ b/src/docusaurus/settings/DocusaurusSettings.ts
@@ -1,9 +1,14 @@
 import { O2PluginSettings } from '../../settings';
 import { DateExtractionPattern } from '../DateExtractionPattern';
+import { PlatformType } from '../../enums/PlatformType';
+import { AuthorStrategy } from '../../strategies/authors/AuthorStrategy';
 
 export default class DocusaurusSettings implements O2PluginSettings {
   docusaurusPath: string;
   dateExtractionPattern: string;
+  authors: string = '';
+  authorStrategy: AuthorStrategy;
+  platform: PlatformType = PlatformType.Docusaurus;
 
   targetPath(): string {
     return `${this.docusaurusPath}/blog`;

--- a/src/enums/PlatformType.ts
+++ b/src/enums/PlatformType.ts
@@ -1,0 +1,6 @@
+export enum PlatformType {
+  Default,
+  Jekyll,
+  Docusaurus,
+  // 추가 플랫폼은 여기에 열거할 수 있습니다.
+}

--- a/src/jekyll/chirpy.ts
+++ b/src/jekyll/chirpy.ts
@@ -24,6 +24,8 @@ export async function convertToChirpy(plugin: O2Plugin) {
         settings.jekyllRelativeResourcePath,
         settings.isEnableBanner,
         settings.isEnableUpdateFrontmatterTimeOnEdit,
+        settings.authors,
+        settings.platform,
       );
       const resourceLinkConverter = new ResourceLinkConverter(
         fileName,

--- a/src/jekyll/settings/JekyllSettings.ts
+++ b/src/jekyll/settings/JekyllSettings.ts
@@ -1,8 +1,12 @@
 import { O2PluginSettings } from '../../settings';
+import { PlatformType } from '../../enums/PlatformType';
 
 export default class JekyllSettings implements O2PluginSettings {
   private _jekyllPath: string;
   private _jekyllRelativeResourcePath: string;
+  authors: string = '';
+  platform: PlatformType = PlatformType.Jekyll;
+
   pathReplacer(year: string, month: string, day: string, title: string): string {
     return `${year}-${month}-${day}-${title}.md`;
   }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -57,6 +57,7 @@ export class O2SettingTab extends PluginSettingTab {
     });
     this.addJekyllPathSetting();
     this.addJekyllRelativeResourcePathSetting();
+    this.addJekyllAuthorsSettings();
 
     // docusaurus settings
     this.containerEl.createEl('h2', {
@@ -64,6 +65,34 @@ export class O2SettingTab extends PluginSettingTab {
     });
     this.addDocusaurusPathSetting();
     this.dateExtractionPatternSetting();
+    this.addDocusaurusAuthorsSettings();
+  }
+  private addJekyllAuthorsSettings() {
+    const jekyllSettings = this.plugin.jekyll as JekyllSettings;
+    new Setting(this.containerEl)
+      .setName('Jekyll Authors')
+      .setDesc('Enter authors separated by commas. For single author, enter only one name.')
+      .addText(text => text
+        .setPlaceholder('author1, author2, ...')
+        .setValue(jekyllSettings.authors)
+        .onChange(async (value) => {
+          jekyllSettings.authors = value;
+          await this.plugin.saveSettings();
+        }));
+  }
+
+  private addDocusaurusAuthorsSettings() {
+    const docusaurusSettings = this.plugin.docusaurus as DocusaurusSettings;
+    new Setting(this.containerEl)
+      .setName('Docusaurus Authors')
+      .setDesc('Enter authors separated by commas. For single author, enter only one name.')
+      .addText(text => text
+        .setPlaceholder('author1, author2, ...')
+        .setValue(docusaurusSettings.authors)
+        .onChange(async (value) => {
+          docusaurusSettings.authors = value;
+          await this.plugin.saveSettings();
+        }));
   }
 
   private enableUpdateFrontmatterTimeOnEditSetting() {

--- a/src/strategies/authors/AuthorStrategy.ts
+++ b/src/strategies/authors/AuthorStrategy.ts
@@ -1,0 +1,6 @@
+import { FrontMatter } from '../../FrontMatterConverter';
+
+export interface AuthorStrategy {
+  applyAuthors(frontMatter: FrontMatter, authors: string): FrontMatter;
+}
+

--- a/src/strategies/authors/DefaultAuthorStrategy.ts
+++ b/src/strategies/authors/DefaultAuthorStrategy.ts
@@ -1,0 +1,8 @@
+import { AuthorStrategy } from './AuthorStrategy';
+import { FrontMatter } from '../../FrontMatterConverter';
+
+export class DefaultAuthorStrategy implements AuthorStrategy {
+  applyAuthors(frontMatter: FrontMatter, authors: string): FrontMatter {
+    return frontMatter;
+  }
+}

--- a/src/strategies/authors/DocusaurusAuthorStrategy.ts
+++ b/src/strategies/authors/DocusaurusAuthorStrategy.ts
@@ -1,0 +1,15 @@
+import { AuthorStrategy } from './AuthorStrategy';
+import { FrontMatter } from '../../FrontMatterConverter';
+
+export class DocusaurusAuthorStrategy implements AuthorStrategy {
+  applyAuthors(frontMatter: FrontMatter, authors: string): FrontMatter {
+    const authorsList = authors.split(',').map(author => author.trim());
+    delete frontMatter.author;
+    if (authorsList.length === 1) {
+      frontMatter.authors = authorsList[0];
+    } else {
+      frontMatter.authors = `[${authorsList.join(', ')}]`;
+    }
+    return frontMatter;
+  }
+}

--- a/src/strategies/authors/JekyllAuthorStrategy.ts
+++ b/src/strategies/authors/JekyllAuthorStrategy.ts
@@ -1,0 +1,15 @@
+import { AuthorStrategy } from './AuthorStrategy';
+import { FrontMatter } from '../../FrontMatterConverter';
+
+export class JekyllAuthorStrategy implements AuthorStrategy {
+  applyAuthors(frontMatter: FrontMatter, authors: string): FrontMatter {
+    const authorsList = authors.split(',').map(author => author.trim());
+    delete frontMatter.authors;
+    if (authorsList.length === 1) {
+      frontMatter.author = authorsList[0];
+    } else {
+      frontMatter.authors = `[${authorsList.join(', ')}]`;
+    }
+    return frontMatter;
+  }
+}

--- a/src/tests/FrontMatterConverter.test.ts
+++ b/src/tests/FrontMatterConverter.test.ts
@@ -1,4 +1,5 @@
 import { convertFrontMatter, FrontMatterConverter } from '../FrontMatterConverter';
+import { PlatformType } from '../enums/PlatformType';
 
 const frontMatterConverter = new FrontMatterConverter('2023-01-01-test-title', 'assets/img', true);
 const disableImageConverter = new FrontMatterConverter('2023-01-01-test-title', 'assets/img', false);
@@ -391,5 +392,151 @@ date: 2021-01-01 12:00:00 +0900
   it('should handle interrupted parsing', () => {
     const result = convertFrontMatter(incompleteFrontMatterContents);
     expect(result).toEqual(incompleteFrontMatterContents); // Assuming the function passes through incomplete front matter as is
+  });
+});
+
+describe('Author/Authors conversion', () => {
+  describe('Jekyll', () => {
+    it('should add single author for Jekyll', () => {
+      const converter = new FrontMatterConverter('test-file', 'assets/img', false, false, 'John Doe', PlatformType.Jekyll);
+      const input = `---
+title: "Test Post"
+---
+Content`;
+      const expected = `---
+title: "Test Post"
+author: John Doe
+---
+
+Content`;
+      expect(converter.convert(input)).toEqual(expected);
+    });
+
+    it('should add multiple authors for Jekyll', () => {
+      const converter = new FrontMatterConverter('test-file', 'assets/img', false, false, 'John Doe, Jane Smith', PlatformType.Jekyll);
+      const input = `---
+title: "Test Post"
+---
+
+Content`;
+      const expected = `---
+title: "Test Post"
+authors: [John Doe, Jane Smith]
+---
+
+Content`;
+      expect(converter.convert(input)).toEqual(expected);
+    });
+
+    it('should overwrite existing author for Jekyll', () => {
+      const converter = new FrontMatterConverter('test-file', 'assets/img', false, false, 'John Doe', PlatformType.Jekyll);
+      const input = `---
+title: "Test Post"
+author: Existing Author
+---
+Content`;
+      const expected = `---
+title: "Test Post"
+author: John Doe
+---
+
+Content`;
+      expect(converter.convert(input)).toEqual(expected);
+    });
+
+    it('should overwrite existing authors with single author for Jekyll', () => {
+      const converter = new FrontMatterConverter('test-file', 'assets/img', false, false, 'John Doe', PlatformType.Jekyll);
+      const input = `---
+title: "Test Post"
+authors: [Existing Author 1, Existing Author 2]
+---
+Content`;
+      const expected = `---
+title: "Test Post"
+author: John Doe
+---
+
+Content`;
+      expect(converter.convert(input)).toEqual(expected);
+    });
+  });
+
+  describe('Docusaurus', () => {
+    it('should add single author for Docusaurus', () => {
+      const converter = new FrontMatterConverter('test-file', 'assets/img', false, false, 'John Doe', PlatformType.Docusaurus);
+      const input = `---
+title: "Test Post"
+---
+
+Content`;
+      const expected = `---
+title: "Test Post"
+authors: John Doe
+---
+
+Content`;
+      expect(converter.convert(input)).toEqual(expected);
+    });
+
+    it('should add multiple authors for Docusaurus', () => {
+      const converter = new FrontMatterConverter('test-file', 'assets/img', false, false, 'John Doe, Jane Smith', PlatformType.Docusaurus);
+      const input = `---
+title: "Test Post"
+---
+Content`;
+      const expected = `---
+title: "Test Post"
+authors: [John Doe, Jane Smith]
+---
+
+Content`;
+      expect(converter.convert(input)).toEqual(expected);
+    });
+
+    it('should overwrite existing authors for Docusaurus', () => {
+      const converter = new FrontMatterConverter('test-file', 'assets/img', false, false, 'John Doe, Jane Smith', PlatformType.Docusaurus);
+      const input = `---
+title: "Test Post"
+authors: Existing Author
+---
+Content`;
+      const expected = `---
+title: "Test Post"
+authors: [John Doe, Jane Smith]
+---
+
+Content`;
+      expect(converter.convert(input)).toEqual(expected);
+    });
+
+    it('should overwrite existing single author with multiple authors for Docusaurus', () => {
+      const converter = new FrontMatterConverter('test-file', 'assets/img', false, false, 'John Doe, Jane Smith', PlatformType.Docusaurus);
+      const input = `---
+title: "Test Post"
+authors: Existing Author
+---
+Content`;
+      const expected = `---
+title: "Test Post"
+authors: [John Doe, Jane Smith]
+---
+
+Content`;
+      expect(converter.convert(input)).toEqual(expected);
+    });
+  });
+
+  it('should not add authors when not provided', () => {
+    const converter = new FrontMatterConverter('test-file', 'assets/img', false, false, '', PlatformType.Docusaurus);
+    const input = `---
+title: "Test Post"
+---
+Content`;
+    const expected = `---
+title: "Test Post"
+---
+
+Content`;
+    expect(converter.convert(input)).toEqual(expected);
   });
 });


### PR DESCRIPTION
- Introduced AuthorStrategyFactory to separate author handling logic for Jekyll and Docusaurus
- Applied author strategies in FrontMatterConverter
- Added `authors` and `platform` fields to DocusaurusSettings and JekyllSettings
- Enhanced O2Settings with UI for author input specific to Jekyll and Docusaurus
- Added test cases for handling multiple authors
- Extended existing defaultAuthor functionality to support multiple authors

# Pull Request

## Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bugfixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
<!-- If this is a PR that resolves the issue, please include the `close` or `resolve` keyword -->

Currently, there is no option to set a default author for Docusaurus conversions. Users have to manually add author information to each markdown file.

Issue Number: N/A


## What is the new behavior?

Currently, there is no option to set a default author for Docusaurus conversions. Users have to manually add author information to each markdown file.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This feature enhances the flexibility of content attribution, allowing for single or multiple authors to be specified seamlessly across different platforms. It improves the user experience by reducing the need for repetitive manual input and ensures consistent author information in the generated frontmatter. 

<img width="1792" alt="image" src="https://github.com/user-attachments/assets/853dd45a-2d1a-44ca-a2ee-dcaf74481cf8">

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a default author setting for front matter in markdown files, enhancing content attribution.
	- Added a user interface option to configure the default author in settings.

- **Bug Fixes**
	- Improved handling of author fields in front matter conversion to ensure defaults are applied correctly.

- **Tests**
	- New test cases added to validate the functionality of the default author settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->