### PR TITLE
feat: Add relative_url filter support for Jekyll image paths

### DIFF
--- a/src/ResourceLinkConverter.ts
+++ b/src/ResourceLinkConverter.ts
@@ -55,10 +55,15 @@ export class ResourceLinkConverter implements Converter {
                       width: string | undefined,
                       height: string | undefined,
                       space: string | undefined,
-                      caption: string | undefined) =>
-      `![image](/${this.relativeResourcePath}/${sanitizedFileName}/${contents.replace(/\s/g, '-')}.${suffix})`
-      + `${convertImageSize(width, height)}`
-      + `${convertImageCaption(caption)}`;
+                      caption: string | undefined) => {
+      const imagePath = `/${this.relativeResourcePath}/${sanitizedFileName}/${contents.replace(/\s/g, '-')}.${suffix}`;
+      const imageUrl = this.liquidFilterOptions.useRelativeUrl
+        ? `{{ "${imagePath}" | relative_url }}`
+        : imagePath;
+      return `![image](${imageUrl})`
+        + `${convertImageSize(width, height)}`
+        + `${convertImageCaption(caption)}`;
+    };
 
     return input.replace(ObsidianRegex.ATTACHMENT_LINK, replacer);
   }

--- a/src/jekyll/settings/JekyllSettings.ts
+++ b/src/jekyll/settings/JekyllSettings.ts
@@ -11,10 +11,12 @@ export default class JekyllSettings implements O2PluginSettings {
   private _isEnableBanner: boolean;
   private _isEnableCurlyBraceConvertMode: boolean;
   private _isEnableUpdateFrontmatterTimeOnEdit: boolean;
+  private _isEnableRelativeUrl: boolean;
 
   constructor() {
     this._jekyllPath = '';
     this._jekyllRelativeResourcePath = 'assets/img';
+    this._isEnableRelativeUrl = false;
   }
 
   get jekyllPath(): string {
@@ -55,6 +57,14 @@ export default class JekyllSettings implements O2PluginSettings {
 
   set isEnableUpdateFrontmatterTimeOnEdit(value: boolean) {
     this._isEnableUpdateFrontmatterTimeOnEdit = value;
+  }
+
+  get isEnableRelativeUrl(): boolean {
+    return this._isEnableRelativeUrl;
+  }
+
+  set isEnableRelativeUrl(value: boolean) {
+    this._isEnableRelativeUrl = value;
   }
 
   targetPath(): string {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -61,6 +61,7 @@ export class O2SettingTab extends PluginSettingTab {
     this.containerEl.createEl('h5', {
       text: 'Liquid Filter',
     });
+    this.addJekyllRelativeUrlSetting();
 
     // docusaurus settings
     this.containerEl.createEl('h3', {
@@ -229,6 +230,19 @@ export class O2SettingTab extends PluginSettingTab {
         .setValue(this.plugin.obsidianPathSettings.isAutoArchive)
         .onChange(async (value) => {
           this.plugin.obsidianPathSettings.isAutoArchive = value;
+          await this.plugin.saveSettings();
+        }));
+  }
+
+  private addJekyllRelativeUrlSetting() {
+    const jekyllSetting = this.plugin.jekyll as JekyllSettings;
+    new Setting(this.containerEl)
+      .setName('Enable relative URL for images')
+      .setDesc('Use Jekyll\'s relative_url filter for image paths. Required when using baseurl.')
+      .addToggle(toggle => toggle
+        .setValue(jekyllSetting.isEnableRelativeUrl)
+        .onChange(async (value) => {
+          jekyllSetting.isEnableRelativeUrl = value;
           await this.plugin.saveSettings();
         }));
   }

--- a/src/tests/ResourceLinkConverter.test.ts
+++ b/src/tests/ResourceLinkConverter.test.ts
@@ -133,20 +133,31 @@ _This is a test image._
 
 });
 
-describe('liquid filter', () => {
-  it('should enable a relative_url', () => {
-    const converter = new ResourceLinkConverter(
-      '2023-01-01-post-mock',
-      'assets',
-      'test',
-      'attachments',
-      'assets',
-      { useRelativeUrl: true },
-    );
+describe('liquid filter with relative_url', () => {
+  const converter = new ResourceLinkConverter(
+    '2023-01-01-post-mock',
+    'assets',
+    'test',
+    'attachments',
+    'assets',
+    { useRelativeUrl: true },
+  );
 
+  it('should wrap image path with relative_url filter', () => {
     const context = `![[test.png]]`;
     const result = converter.convert(context);
-
     expect(result).toEqual(`![image]({{ "/assets/2023-01-01-post-mock/test.png" | relative_url }})`);
+  });
+
+  it('should handle images with size specifications', () => {
+    const context = `![[test.png|100x200]]`;
+    const result = converter.convert(context);
+    expect(result).toEqual(`![image]({{ "/assets/2023-01-01-post-mock/test.png" | relative_url }}){: width="100" height="200" }`);
+  });
+
+  it('should handle images with captions', () => {
+    const context = `![[test.png]]\n_Image caption_`;
+    const result = converter.convert(context);
+    expect(result).toEqual(`![image]({{ "/assets/2023-01-01-post-mock/test.png" | relative_url }})\n_Image caption_`);
   });
 });


### PR DESCRIPTION
- Add isEnableRelativeUrl setting to JekyllSettings
- Add UI toggle for relative_url filter in settings
- Update ResourceLinkConverter to handle relative_url filter
- Add comprehensive tests for relative_url functionality

This change allows proper image path handling when Jekyll baseurl is configured, particularly useful for GitHub Pages deployments.

# Pull Request

## Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bugfixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
<!-- If this is a PR that resolves the issue, please include the `close` or `resolve` keyword -->

Issue Number: #405 


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<img width="677" alt="image" src="https://github.com/user-attachments/assets/cb18488d-1103-44cf-a351-f63cc180c293" />
