### PR TITLE
feat: Moving the finished note to something other than _posts

### DIFF
--- a/src/jekyll/chirpy.ts
+++ b/src/jekyll/chirpy.ts
@@ -54,18 +54,17 @@ export async function convertToChirpy(plugin: O2Plugin) {
       await plugin.app.vault.modify(file, result);
 
       // Where can I create this code block(create a function)?
-      const path:string = file.path;
-      const directory = path.substring(0, path.lastIndexOf("/"));
-      const folder = directory.substring(directory.lastIndexOf("/") + 1);
+      const path: string = file.path;
+      const directory = path.substring(0, path.lastIndexOf('/'));
+      const folder = directory.substring(directory.lastIndexOf('/') + 1);
       // end code block
 
-      if(folder !== plugin.obsidianPathSettings.readyFolder){
+      if (folder !== plugin.obsidianPathSettings.readyFolder) {
         await moveFiles(
           `${vaultAbsolutePath(plugin)}/${plugin.obsidianPathSettings.readyFolder}/${folder}`,
           settings.targetSubPath(folder),
           settings.pathReplacer,
         ).then(() => new Notice('Moved files to Chirpy successfully.', 5000));
-
       } else {
         await moveFiles(
           `${vaultAbsolutePath(plugin)}/${plugin.obsidianPathSettings.readyFolder}`,

--- a/src/jekyll/chirpy.ts
+++ b/src/jekyll/chirpy.ts
@@ -52,11 +52,27 @@ export async function convertToChirpy(plugin: O2Plugin) {
         .converting(await plugin.app.vault.read(file));
 
       await plugin.app.vault.modify(file, result);
-      await moveFiles(
-        `${vaultAbsolutePath(plugin)}/${plugin.obsidianPathSettings.readyFolder}`,
-        settings.targetPath(),
-        settings.pathReplacer,
-      ).then(() => new Notice('Moved files to Chirpy successfully.', 5000));
+
+      // Where can I create this code block(create a function)?
+      const path:string = file.path;
+      const directory = path.substring(0, path.lastIndexOf("/"));
+      const folder = directory.substring(directory.lastIndexOf("/") + 1);
+      // end code block
+
+      if(folder !== plugin.obsidianPathSettings.readyFolder){
+        await moveFiles(
+          `${vaultAbsolutePath(plugin)}/${plugin.obsidianPathSettings.readyFolder}/${folder}`,
+          settings.targetSubPath(folder),
+          settings.pathReplacer,
+        ).then(() => new Notice('Moved files to Chirpy successfully.', 5000));
+
+      } else {
+        await moveFiles(
+          `${vaultAbsolutePath(plugin)}/${plugin.obsidianPathSettings.readyFolder}`,
+          settings.targetPath(),
+          settings.pathReplacer,
+        ).then(() => new Notice('Moved files to Chirpy successfully.', 5000));
+      }
     }
   } catch (e) {
     console.error(e);

--- a/src/jekyll/chirpy.ts
+++ b/src/jekyll/chirpy.ts
@@ -53,11 +53,9 @@ export async function convertToChirpy(plugin: O2Plugin) {
 
       await plugin.app.vault.modify(file, result);
 
-      // Where can I create this code block(create a function)?
       const path: string = file.path;
       const directory = path.substring(0, path.lastIndexOf('/'));
       const folder = directory.substring(directory.lastIndexOf('/') + 1);
-      // end code block
 
       if (folder !== plugin.obsidianPathSettings.readyFolder) {
         await moveFiles(

--- a/src/jekyll/settings/JekyllSettings.ts
+++ b/src/jekyll/settings/JekyllSettings.ts
@@ -76,7 +76,7 @@ export default class JekyllSettings implements O2PluginSettings {
     return `${this._jekyllPath}/_posts`;
   }
 
-  targetSubPath(folder:string) {
+  targetSubPath(folder: string) {
     return `${this._jekyllPath}/${folder}`;
   }
 

--- a/src/jekyll/settings/JekyllSettings.ts
+++ b/src/jekyll/settings/JekyllSettings.ts
@@ -76,6 +76,10 @@ export default class JekyllSettings implements O2PluginSettings {
     return `${this._jekyllPath}/_posts`;
   }
 
+  targetSubPath(folder:string) {
+    return `${this._jekyllPath}/${folder}`;
+  }
+
   resourcePath(): string {
     return `${this._jekyllPath}/${this._jekyllRelativeResourcePath}`;
   }


### PR DESCRIPTION
# Pull Request

## Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bugfixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently, all finished notes are moved to the default `_posts` folder, which may cause disorganization and difficulty managing content, especially for users of static site generators like Jekyll.

Issue Number: #363

## What is the new behavior?

This feature allows finished notes to be moved to a location other than the default `_posts` folder, improving organization and content management. It helps separate draft, published, or archived notes from ongoing posts, enhancing the workflow and structure of the content.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This change provides better content organization and is fully backward-compatible, as it adds flexibility in where finished notes can be stored without affecting existing workflows. I ran the existing tests, and they passed successfully; however, I did not create new tests specifically for this feature.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced file handling logic for improved flexibility in moving processed files.
	- Introduced a new method to dynamically generate sub-paths within the Jekyll directory.

- **Documentation**
	- Added comments to indicate potential refactoring points for future development.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->