### PR TITLE
fix(JekyllSettings.ts): adding convertFileName to the title variable

### DIFF
--- a/src/jekyll/settings/JekyllSettings.ts
+++ b/src/jekyll/settings/JekyllSettings.ts
@@ -1,4 +1,5 @@
 import { O2PluginSettings } from '../../settings';
+import { convertFileName } from '../../FilenameConverter';
 
 export default class JekyllSettings implements O2PluginSettings {
   private _jekyllPath: string;
@@ -9,6 +10,7 @@ export default class JekyllSettings implements O2PluginSettings {
     day: string,
     title: string,
   ): string {
+    title = convertFileName(title);
     return `${year}-${month}-${day}-${title}.md`;
   }
 


### PR DESCRIPTION
# Pull Request

## Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bugfixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. --> 
<!-- If this is a PR that resolves the issue, please include the `close` or `resolve` keyword -->

Issue Number:  #399

## What is the new behavior?
Replaces the parentheses in the file name with hyphens.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

The error in not converting the file name occurs because the change is being made only in the front matter, which causes the inconsistency.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced filename conversion for Jekyll settings, improving title processing and formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->